### PR TITLE
Handle extra output in thread dump for CompilerThread

### DIFF
--- a/src/main/java/io/airlift/stackfold/StackFolder.java
+++ b/src/main/java/io/airlift/stackfold/StackFolder.java
@@ -124,8 +124,9 @@ public final class StackFolder
             while (lineIterator.hasNext()) {
                 line = lineIterator.peek().trim();
 
-                // stop when we see a blank line or the start of the next thread
-                if (line.isEmpty() || THREAD_INFO_PATTERN.matcher(line).matches()) {
+                // stop when we see a blank line or the start of the next thread or if its a compiler thread
+                // compiler thread spits out an extra line that does not fit the pattern in STACK_ELEMENT_PATTERN
+                if (line.isEmpty() || THREAD_INFO_PATTERN.matcher(line).matches() || name.contains("CompilerThread")) {
                     break;
                 }
 

--- a/src/test/resources/stack.txt
+++ b/src/test/resources/stack.txt
@@ -12,6 +12,7 @@ Full thread dump Java HotSpot(TM) 64-Bit Server VM (23.25-b01 mixed mode):
 
 "C2 CompilerThread0" daemon prio=5 tid=0x00007fda14896800 nid=0x5103 waiting on condition [0x0000000000000000]
    java.lang.Thread.State: RUNNABLE
+   No compile task
 
 "Signal Dispatcher" daemon prio=5 tid=0x00007fda14895800 nid=0x5003 runnable [0x0000000000000000]
    java.lang.Thread.State: RUNNABLE


### PR DESCRIPTION
The thread dump for CompilerThread includes a line "No compile task". This does not match the pattern in STACK_ELEMENT_PATTERN and stackfold fails to parse the thread dump from jstack. I wanted to add a check [here](https://github.com/airlift/stackfold/blob/1c791b2d8ac2c64247d506730f20cb3b2203296e/src/main/java/io/airlift/stackfold/StackFolder.java#L133) to see if a line matches STACK_ELEMENT_PATTERN. I wasn't sure about the intent of the original check (line does not begin with "-"), so I ended up adding the 'name.contains("CompilerThread")' check instead.